### PR TITLE
fix: modify configs search-locations path

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -3,7 +3,7 @@ spring:
     config:
       server:
         native:
-          search-locations: file:./configs/{application}
+          search-locations: file:${CONFIG_REPO_PATH}/{application}
 
 eureka:
   client:


### PR DESCRIPTION
## ✅ 구현된 기능
- config 서버 실행시, VM 옵션으로 configs 파일의 절대 경로를 입력
- 각자 프로젝트 저장 위치에 맞는 옵션 설정 필요

(정상적인 작동 확인)
<img width="1894" height="813" alt="유레카서버" src="https://github.com/user-attachments/assets/4aa167fe-2046-4625-ba87-1c3dd6c7355b" />

(VM 옵션 예시)
-DCONFIG_REPO_PATH=C:/Users/minah/Documents/outback/dollar-config/configs

<img width="1185" height="692" alt="vm 옵션 참고" src="https://github.com/user-attachments/assets/bc163a41-23a8-4c2b-99fc-3a9667b27fc1" />


---

## 🚨 리뷰 포인트
<!-- 특별히 봐줬으면 하는 부분 -->
- classpath로 설정하는 방법 고려 : JAR 파일 안에 해당 configs 설정이 묶이기 때문에 수정이 있을 때마다 재빌드 및 재배포 필요
- git 주소로 설정하는 방법 고려 : 로컬용 세팅이기에 git 보다는 로컬 컴퓨터에서 설정을 가져오는게 맞다고 판단
-> VM 옵션 설정을 각자 해야하는 부분이 있지만, 해당 방법이 가장 적절하다고 생각하여 이 방법으로 수정하였습니다
